### PR TITLE
Improve code structure and reduce coupling

### DIFF
--- a/boltpage/BRIEFING.md
+++ b/boltpage/BRIEFING.md
@@ -26,8 +26,9 @@ BoltPage is a fast Markdown viewer and editor built with Rust and Tauri. It rend
 ## Critical Decisions
 1. **Async Mutex**: Uses tokio::sync::Mutex throughout for consistency with async runtime. All .lock() calls require .await.
 2. **No hardcoded paths**: File paths resolved via resolve_file_path to handle URLs, relative, and absolute paths uniformly.
-3. **Debouncing**: File change notifications (250ms) and window resize saves (450ms) to reduce I/O and state updates.
+3. **Debouncing**: File change notifications (250ms), window resize saves (450ms), and scroll sync broadcasts (50ms) to reduce I/O and state updates.
 4. **Cache invalidation**: File watchers invalidate HTML cache entries on modification to ensure fresh renders.
+5. **Scroll Sync Parameters**: Line height fallback (1.4x font-size), programmatic scroll timeout (100ms), delta thresholds (0.5 lines or 1% for markdown) prevent jitter and echo loops between editor and viewer windows.
 
 ## Known Constraints
 - macOS 10.13+ required for builds

--- a/boltpage/CHANGES.md
+++ b/boltpage/CHANGES.md
@@ -9,3 +9,11 @@
 2025-11-19: Fix Resized handler lifetime error (clone AppHandle before moving into async task)
 2025-11-19: Fix formatting issues (return statements on same line as closing braces)
 2025-11-19: Fix Resized handler borrow checker error (extract Arc directly instead of cloning entire state)
+2025-11-19: Unify line height calculation (1.4 multiplier) across editor.js and main.js to eliminate vertical misalignment
+2025-11-19: Replace requestAnimationFrame with setTimeout (50ms) for scroll sync debouncing to reduce broadcast frequency
+2025-11-19: Increase programmatic scroll timeout (0ms to 100ms) to prevent echo loops between editor and viewer
+2025-11-19: Add scroll delta thresholds (0.5 lines, 1% for markdown) to filter micro-scroll events and eliminate jitter
+2025-11-19: Replace scrollTo with direct scrollTop assignment for consistent cross-browser scroll behavior
+2025-11-19: Fix percentage calculation edge case (check scrollableHeight > 0 before dividing)
+2025-11-19: Add offset calculation caching in main.js to avoid repeated DOM walking during scroll events
+2025-11-19: Add txt file type to scroll sync handlers (was missing from preview listener)


### PR DESCRIPTION
Root causes addressed:
- Line height calculation mismatch (1.4x vs 1.2x fallback)
- Race conditions with 0ms programmatic scroll timeout
- No debouncing threshold causing constant broadcasts
- Inconsistent scroll mechanisms (scrollTo vs scrollTop)
- Percentage calculation edge case (divide by 1 when content fits)
- Expensive DOM walking on every scroll event

Changes:
- Unify LINE_HEIGHT_FALLBACK_MULTIPLIER to 1.4 in both files
- Increase PROGRAMMATIC_SCROLL_TIMEOUT_MS from 0 to 100
- Replace requestAnimationFrame with setTimeout(50ms) debouncing
- Add MIN_SCROLL_DELTA_LINES (0.5) and MIN_SCROLL_DELTA_PERCENT (0.01) thresholds
- Track lastSyncedLine/lastSyncedPercent to filter micro-scrolls
- Replace scrollTo with direct scrollTop assignment
- Fix scrollableHeight checks (>0 before dividing)
- Cache offset calculations in main.js getPreAndMetrics
- Add txt file type handling to preview scroll sync listener

All constants parameterized for future tuning.