### PR TITLE
Fix GitHub Actions build ID issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   # Quick validation
   check:
     name: Quick Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
   # Lint and format
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: check
     steps:
       - name: Checkout repository
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-14, windows-latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -90,10 +90,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install system dependencies (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.0-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -121,7 +121,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-14, windows-latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -137,10 +137,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install system dependencies (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.0-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -166,7 +166,7 @@ jobs:
   # Final status check
   ci-success:
     name: CI Success
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [check, lint, test, build]
     if: always()
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,7 +19,7 @@ jobs:
   # Fast checks that run first
   lint:
     name: Lint and Format Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-14, windows-latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -67,10 +67,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install system dependencies (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.0-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -94,12 +94,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-14, windows-latest]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - os: macos-latest
-            target: x86_64-apple-darwin
+          - os: macos-14
+            target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
     steps:
@@ -119,10 +119,10 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install system dependencies (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.0-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -149,9 +149,9 @@ jobs:
       - name: Check build artifacts
         shell: bash
         run: |
-          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+          if [ "${{ matrix.os }}" = "ubuntu-22.04" ]; then
             ls -lh boltpage/src-tauri/target/${{ matrix.target }}/release/bundle/
-          elif [ "${{ matrix.os }}" = "macos-latest" ]; then
+          elif [ "${{ matrix.os }}" = "macos-14" ]; then
             ls -lh boltpage/src-tauri/target/${{ matrix.target }}/release/bundle/
           elif [ "${{ matrix.os }}" = "windows-latest" ]; then
             ls boltpage/src-tauri/target/${{ matrix.target }}/release/bundle/
@@ -160,7 +160,7 @@ jobs:
   # Summary job
   pr-checks-summary:
     name: PR Checks Summary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [lint, test, build-verify]
     if: always()
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,25 +8,27 @@ on:
 
 jobs:
   build-macos:
-    runs-on: macos-latest
-    
+    runs-on: macos-14
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-      
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
         cache-dependency-path: 'boltpage/package-lock.json'
-        
+
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
-        
+      with:
+        targets: aarch64-apple-darwin,x86_64-apple-darwin
+
     - name: Install Tauri CLI
       run: npm install -g @tauri-apps/cli
-      
+
     - name: Install dependencies
       run: |
         cd boltpage
@@ -70,7 +72,7 @@ PY
         # Verify certificate
         security find-identity -v -p codesigning build.keychain
         
-    - name: Build macOS app
+    - name: Build macOS app (ARM64)
       env:
         APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -78,27 +80,63 @@ PY
         APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
       run: |
         cd boltpage
-        npx tauri build
+        npx tauri build --target aarch64-apple-darwin
+
+    - name: Build macOS app (x86_64)
+      env:
+        APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+      run: |
+        cd boltpage
+        npx tauri build --target x86_64-apple-darwin
         
-    - name: Notarize macOS app
+    - name: Notarize macOS ARM64 app
       env:
         APPLE_ID: ${{ secrets.APPLE_ID }}
         APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       run: |
-        cd boltpage/src-tauri/target/release/bundle/dmg
-        xcrun notarytool submit BoltPage_*.dmg --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
-        
+        cd boltpage/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg
+        for dmg in BoltPage_*.dmg; do
+          xcrun notarytool submit "$dmg" --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
+        done
+
+    - name: Notarize macOS x86_64 app
+      env:
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      run: |
+        cd boltpage/src-tauri/target/x86_64-apple-darwin/release/bundle/dmg
+        for dmg in BoltPage_*.dmg; do
+          xcrun notarytool submit "$dmg" --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
+        done
+
     - name: Staple notarization
       run: |
-        cd boltpage/src-tauri/target/release/bundle/dmg
-        xcrun stapler staple BoltPage_*.dmg
-        
-    - name: Upload macOS artifacts
+        cd boltpage/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg
+        for dmg in BoltPage_*.dmg; do
+          xcrun stapler staple "$dmg"
+        done
+        cd ../../../../../x86_64-apple-darwin/release/bundle/dmg
+        for dmg in BoltPage_*.dmg; do
+          xcrun stapler staple "$dmg"
+        done
+
+    - name: Upload macOS ARM64 artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: macos-build
-        path: boltpage/src-tauri/target/release/bundle/dmg/
+        name: macos-arm64-build
+        path: boltpage/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/
+        retention-days: 30
+
+    - name: Upload macOS x86_64 artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: macos-x64-build
+        path: boltpage/src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/
         retention-days: 30
         
     - name: Clean up keychain
@@ -116,10 +154,10 @@ PY
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
         cache-dependency-path: 'boltpage/package-lock.json'
-        
+
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
       with:
@@ -171,23 +209,29 @@ PY
     needs: [build-macos, build-windows]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-      
-    - name: Download macOS artifacts
+
+    - name: Download macOS ARM64 artifacts
       uses: actions/download-artifact@v4
       with:
-        name: macos-build
-        path: ./macos-build
-        
+        name: macos-arm64-build
+        path: ./macos-arm64-build
+
+    - name: Download macOS x86_64 artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: macos-x64-build
+        path: ./macos-x64-build
+
     - name: Download Windows artifacts
       uses: actions/download-artifact@v4
       with:
         name: windows-build
         path: ./windows-build
-        
+
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
@@ -195,15 +239,17 @@ PY
         name: BoltPage ${{ github.ref_name }}
         body: |
           ## BoltPage ${{ github.ref_name }}
-          
+
           ### Downloads
-          - **macOS**: Download the `.dmg` file below
+          - **macOS (Apple Silicon)**: Download the `*_aarch64.dmg` file below
+          - **macOS (Intel)**: Download the `*_x64.dmg` file below
           - **Windows**: Download the `.exe` installer below
-          
+
           ### Changes
           See the commit history for detailed changes.
         files: |
-          ./macos-build/*.dmg
+          ./macos-arm64-build/*.dmg
+          ./macos-x64-build/*.dmg
           ./windows-build/nsis/*.exe
         draft: false
         prerelease: false


### PR DESCRIPTION
- Update Ubuntu from ubuntu-latest to ubuntu-22.04 (ubuntu-latest is now Ubuntu 24.04 which lacks required WebKit libraries)
- Change libwebkit2gtk-4.0-dev to libwebkit2gtk-4.1-dev (Tauri 2 requires 4.1)
- Add patchelf dependency for Linux builds
- Update macOS from macos-latest to macos-14 (now Apple Silicon by default)
- Change macOS target from x86_64-apple-darwin to aarch64-apple-darwin
- Build both ARM64 and x86_64 binaries for macOS releases
- Upgrade Node.js to version 20 for consistency
- Update release workflow to upload separate ARM64 and x64 DMGs