### PR TITLE
Fix Windows certificate missing in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,15 +163,13 @@ jobs:
         npm install
         
     - name: Setup Windows code signing
+      if: ${{ secrets.WINDOWS_CERTIFICATE != '' }}
       env:
         WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
         WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
       shell: pwsh
       run: |
-        if (-not $Env:WINDOWS_CERTIFICATE) {
-          Write-Error "WINDOWS_CERTIFICATE is empty or missing"
-          exit 1
-        }
+        Write-Host "Setting up Windows code signing..."
         try {
           [IO.File]::WriteAllBytes("certificate.pfx", [Convert]::FromBase64String($Env:WINDOWS_CERTIFICATE))
         } catch {
@@ -183,6 +181,14 @@ jobs:
           exit 1
         }
         certutil -user -p "$Env:WINDOWS_CERTIFICATE_PASSWORD" -importPFX certificate.pfx
+        Write-Host "Windows code signing certificate installed successfully"
+
+    - name: Skip Windows code signing (no certificate)
+      if: ${{ secrets.WINDOWS_CERTIFICATE == '' }}
+      shell: pwsh
+      run: |
+        Write-Host "::warning::WINDOWS_CERTIFICATE not configured - Windows build will not be code signed"
+        Write-Host "Users may see 'unknown publisher' warnings when installing the app"
         
     - name: Build Windows app
       run: |


### PR DESCRIPTION
- Add conditional check to skip signing setup when WINDOWS_CERTIFICATE secret is not configured
- Add informational warning step when building without code signing
- Windows builds will now succeed without certificates (users will see "unknown publisher" warning on install)