### PR TITLE
Fix macOS notarization failure in GitHub build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       run: |
-        cd boltpage/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg
+        cd boltpage/target/aarch64-apple-darwin/release/bundle/dmg
         for dmg in BoltPage_*.dmg; do
           xcrun notarytool submit "$dmg" --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
         done
@@ -100,18 +100,18 @@ jobs:
         APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       run: |
-        cd boltpage/src-tauri/target/x86_64-apple-darwin/release/bundle/dmg
+        cd boltpage/target/x86_64-apple-darwin/release/bundle/dmg
         for dmg in BoltPage_*.dmg; do
           xcrun notarytool submit "$dmg" --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
         done
 
     - name: Staple notarization
       run: |
-        cd boltpage/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg
+        cd boltpage/target/aarch64-apple-darwin/release/bundle/dmg
         for dmg in BoltPage_*.dmg; do
           xcrun stapler staple "$dmg"
         done
-        cd ../../../../../x86_64-apple-darwin/release/bundle/dmg
+        cd ../../../../x86_64-apple-darwin/release/bundle/dmg
         for dmg in BoltPage_*.dmg; do
           xcrun stapler staple "$dmg"
         done
@@ -120,14 +120,14 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: macos-arm64-build
-        path: boltpage/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/
+        path: boltpage/target/aarch64-apple-darwin/release/bundle/dmg/
         retention-days: 30
 
     - name: Upload macOS x86_64 artifacts
       uses: actions/upload-artifact@v4
       with:
         name: macos-x64-build
-        path: boltpage/src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/
+        path: boltpage/target/x86_64-apple-darwin/release/bundle/dmg/
         retention-days: 30
         
     - name: Clean up keychain
@@ -199,7 +199,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: windows-build
-        path: boltpage/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/
+        path: boltpage/target/x86_64-pc-windows-msvc/release/bundle/
         retention-days: 30
 
   create-release:


### PR DESCRIPTION
The build output directory is at the workspace level (boltpage/target/) not inside src-tauri, because there's a Cargo workspace at boltpage/. This caused the notarization step to fail with "No such file or directory".

Updated paths:
- boltpage/src-tauri/target/ -> boltpage/target/
- Fixed relative path in staple step (5 levels -> 4 levels)