### PR TITLE
Fix GitHub release workflow 403 error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,8 @@ jobs:
     needs: [build-macos, build-windows]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
The create-release job was failing with a 403 error because the GITHUB_TOKEN lacked write permissions to create releases. Added explicit contents: write permission to the job.