### PR TITLE
v2.2.1: security and data-loss fixes

### DIFF
--- a/BRIEFING.md
+++ b/BRIEFING.md
@@ -46,7 +46,7 @@
   - Scroll sync: line height 1.4x, programmatic timeout 100ms, delta thresholds.
   - Debug builds use debug_log macro (eprintln); release builds strip it.
   - Run cargo fmt before committing Rust code.
-  - Release tags must be lightweight, not annotated.
+  - Release tags must be lightweight (not annotated) and applied on main: merge dev into main first, then tag, so every release tag is an ancestor of main. main is branch-protected with a required "CI Success" check (CI runs on PRs, not pushes), so reach it via a PR rather than a direct push.
   - Version source of truth is package.json; scripts/sync-version.sh propagates to tauri.conf.json and Cargo.toml (Cargo.lock via cargo check, Homebrew cask updated manually).
   - UI chrome aligned to Apple HIG: 38pt titlebar material, 10px window radius, 6px control radii, three themes (light/dark/drac), native font stack; .markdown-body keeps serif stack.
   - Cross-window preference broadcasts follow echo-suppression pattern: listener compares payload to local state and early-returns on match (theme, font-size, toolbar-density).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -99,3 +99,8 @@ Format: `YYYY-MM-DD [type] description` (max 200 chars). Types: decision, plan, 
 2026-06-15 [code] ci.yml build-verify uses per-OS --bundles (mac app,dmg / win nsis); build-release.sh drops version sync duplicated by sync-version.sh (removed two now-dead fns).
 2026-06-15 [note] Released v2.2.0 from dev commit 80e9a7c (Release run 27570714819 succeeded: signed/notarized macOS + Windows, public GitHub Release); merging dev into main so main is back on the release line (all prior tags were on main).
 2026-06-15 [note] Merged dev into main for v2.2.0 (main now f7b4e06); direct push bypassed main's required 'CI Success' branch-protection check (CI runs on PRs not pushes); prefer a PR to main next time.
+2026-06-15 [code] Security fixes: create_new_window_command no longer accepts a path (webview could self-authorize arbitrary files via io::allow_path); blank-window only, file opens stay in trusted Rust paths.
+2026-06-15 [code] Autosave hardened: saves serialized via isSaving/pendingSave (no overlapping/out-of-order writes); isDirty cleared only when buffer still matches the write, so edits during an in-flight save aren't dropped.
+2026-06-15 [code] saveFile returns success; editor close handler aborts window destroy on a failed final save (disk-full/permission/replaced) instead of discarding the unsaved buffer.
+2026-06-15 [code] Workspace index no longer follows directory symlinks escaping the root (canonical-containment check in walk_workspace); regression test added; closing a workspace now revokes the allowed_dirs grant via io::revoke_dir.
+2026-06-15 [note] Version bumped 2.2.0 to 2.2.1 (package.json, tauri.conf.json, Cargo.toml, Cargo.lock) for the five security/data-loss fixes; Homebrew cask bumped at release.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,3 +98,4 @@ Format: `YYYY-MM-DD [type] description` (max 200 chars). Types: decision, plan, 
 2026-06-15 [code] release.yml: Windows signing injects bundle.windows.certificateThumbprint from imported PFX (was a no-op); win --bundles nsis; npm ci; keychain 6h timeout; gh-release pinned to v3.0.0 SHA.
 2026-06-15 [code] ci.yml build-verify uses per-OS --bundles (mac app,dmg / win nsis); build-release.sh drops version sync duplicated by sync-version.sh (removed two now-dead fns).
 2026-06-15 [note] Released v2.2.0 from dev commit 80e9a7c (Release run 27570714819 succeeded: signed/notarized macOS + Windows, public GitHub Release); merging dev into main so main is back on the release line (all prior tags were on main).
+2026-06-15 [note] Merged dev into main for v2.2.0 (main now f7b4e06); direct push bypassed main's required 'CI Success' branch-protection check (CI runs on PRs not pushes); prefer a PR to main next time.

--- a/boltpage/Cargo.lock
+++ b/boltpage/Cargo.lock
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "boltpage"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "base64 0.22.1",
  "lru",

--- a/boltpage/package.json
+++ b/boltpage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "BoltPage",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "scripts": {
     "tauri": "tauri"

--- a/boltpage/src-tauri/Cargo.toml
+++ b/boltpage/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boltpage"
-version = "2.2.0"
+version = "2.2.1"
 description = "A Tauri App"
 authors = ["BoltPage Contributors"]
 edition = "2021"

--- a/boltpage/src-tauri/src/io.rs
+++ b/boltpage/src-tauri/src/io.rs
@@ -109,6 +109,21 @@ pub(crate) fn allow_dir(app: &AppHandle, dir: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Revoke a previously granted folder (e.g. when the user closes the
+/// workspace), so backend commands stop passing its prefix check. Best-effort:
+/// a non-canonicalizable path matches nothing in the set and is a no-op.
+pub(crate) fn revoke_dir(app: &AppHandle, dir: &str) {
+    let Ok(canonical) = fs::canonicalize(dir) else {
+        return;
+    };
+    let state = app.state::<AppState>();
+    state
+        .allowed_dirs
+        .write()
+        .expect("allowed_dirs lock poisoned")
+        .remove(&canonical);
+}
+
 /// Register a path as allowed for file I/O commands.
 pub(crate) fn allow_path(app: &AppHandle, path: &str) {
     let normalized = normalize_path(path);

--- a/boltpage/src-tauri/src/lib.rs
+++ b/boltpage/src-tauri/src/lib.rs
@@ -399,7 +399,7 @@ pub fn run() {
                         MENU_NEW_WINDOW => {
                             let app_clone = app.clone();
                             tauri::async_runtime::spawn(async move {
-                                let _ = window::create_new_window_command(app_clone, None).await;
+                                let _ = window::create_new_window_command(app_clone).await;
                             });
                         }
                         MENU_PRINT | MENU_EXPORT_PDF => {

--- a/boltpage/src-tauri/src/window.rs
+++ b/boltpage/src-tauri/src/window.rs
@@ -286,12 +286,12 @@ pub(crate) async fn open_editor_window(
 }
 
 #[tauri::command]
-pub(crate) async fn create_new_window_command(
-    app: AppHandle,
-    file_path: Option<String>,
-) -> Result<String, String> {
-    let resolved_path = file_path.and_then(|p| io::resolve_file_path(&p));
-    create_window_with_file(&app, resolved_path)
+pub(crate) async fn create_new_window_command(app: AppHandle) -> Result<String, String> {
+    // Always a blank window: the webview must not be able to pass an arbitrary
+    // path here, because create_window_with_file grants it via io::allow_path.
+    // File-bearing opens go through trusted Rust entry points (CLI, Launch
+    // Services, recents/menu) that call create_window_with_file directly.
+    create_window_with_file(&app, None)
         .await
         .map_err(|e| format!("Failed to create window: {e}"))
 }

--- a/boltpage/src-tauri/src/workspace.rs
+++ b/boltpage/src-tauri/src/workspace.rs
@@ -194,7 +194,7 @@ pub(crate) async fn list_workspace_files(app: AppHandle) -> Result<WorkspaceFile
         let mut files = Vec::new();
         let mut truncated = false;
         walk_workspace(&root, &root, &canonical_root, 0, &mut files, &mut truncated);
-        files.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        files.sort_by_key(|a| a.name.to_lowercase());
         Ok(WorkspaceFiles { files, truncated })
     })
     .await

--- a/boltpage/src-tauri/src/workspace.rs
+++ b/boltpage/src-tauri/src/workspace.rs
@@ -64,6 +64,7 @@ fn list_dir_inner(dir: &Path) -> Result<Vec<DirEntryInfo>, String> {
 fn walk_workspace(
     dir: &Path,
     root: &Path,
+    canonical_root: &Path,
     depth: usize,
     out: &mut Vec<DirEntryInfo>,
     truncated: &mut bool,
@@ -82,7 +83,15 @@ fn walk_workspace(
         }
         let path = PathBuf::from(&entry.path);
         if entry.is_dir {
-            walk_workspace(&path, root, depth + 1, out, truncated);
+            // Don't follow directory symlinks that escape the workspace: only
+            // recurse when the canonical target stays under the granted root,
+            // so the index can't disclose paths outside the folder.
+            match fs::canonicalize(&path) {
+                Ok(canon) if canon.starts_with(canonical_root) => {
+                    walk_workspace(&path, root, canonical_root, depth + 1, out, truncated);
+                }
+                _ => continue,
+            }
         } else {
             // Join components with '/' explicitly so switcher labels are
             // identical across platforms (Windows would otherwise emit '\').
@@ -148,6 +157,12 @@ pub(crate) async fn get_workspace_folder(app: AppHandle) -> Result<Option<String
 
 #[tauri::command]
 pub(crate) async fn clear_workspace_folder(app: AppHandle) -> Result<(), String> {
+    // Revoke the directory grant, not just the preference: otherwise the folder
+    // stays in allowed_dirs and backend commands keep read/write access to it
+    // until the process exits.
+    if let Some(folder) = prefs::read_string_pref(&app, "workspace_folder") {
+        io::revoke_dir(&app, &folder);
+    }
     prefs::save_preference_key_inner(&app, "workspace_folder", serde_json::Value::Null).await
 }
 
@@ -173,10 +188,12 @@ pub(crate) async fn list_workspace_files(app: AppHandle) -> Result<WorkspaceFile
     };
     io::check_path_allowed(&app, &folder)?;
     let root = PathBuf::from(folder);
+    let canonical_root =
+        fs::canonicalize(&root).map_err(|e| format!("Failed to resolve workspace: {e}"))?;
     tauri::async_runtime::spawn_blocking(move || {
         let mut files = Vec::new();
         let mut truncated = false;
-        walk_workspace(&root, &root, 0, &mut files, &mut truncated);
+        walk_workspace(&root, &root, &canonical_root, 0, &mut files, &mut truncated);
         files.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
         Ok(WorkspaceFiles { files, truncated })
     })
@@ -224,7 +241,8 @@ mod tests {
 
         let mut files = Vec::new();
         let mut truncated = false;
-        walk_workspace(&root, &root, 0, &mut files, &mut truncated);
+        let canonical_root = fs::canonicalize(&root).unwrap();
+        walk_workspace(&root, &root, &canonical_root, 0, &mut files, &mut truncated);
         let mut names: Vec<String> = files.iter().map(|f| f.name.clone()).collect();
         names.sort();
         assert_eq!(
@@ -234,5 +252,26 @@ mod tests {
         assert!(!truncated);
 
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walk_workspace_skips_symlink_escape() {
+        let root = unique_temp_dir();
+        let outside = unique_temp_dir();
+        fs::write(outside.join("secret.md"), "x").unwrap();
+        fs::write(root.join("inside.md"), "x").unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("link")).unwrap();
+
+        let mut files = Vec::new();
+        let mut truncated = false;
+        let canonical_root = fs::canonicalize(&root).unwrap();
+        walk_workspace(&root, &root, &canonical_root, 0, &mut files, &mut truncated);
+        let names: Vec<String> = files.iter().map(|f| f.name.clone()).collect();
+        // The symlinked external dir must not be followed: only inside.md.
+        assert_eq!(names, vec!["inside.md".to_string()]);
+
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(outside).unwrap();
     }
 }

--- a/boltpage/src-tauri/tauri.conf.json
+++ b/boltpage/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "BoltPage",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "identifier": "com.dpm.boltpage",
   "build": {
     "frontendDist": "../src",

--- a/boltpage/src/editor.js
+++ b/boltpage/src/editor.js
@@ -96,6 +96,10 @@ let currentFileKind = KIND_MARKDOWN;
 let editorView = null;
 let isDirty = false;
 let saveTimeout = null;
+// Serialize saves: a save in flight defers the next request via pendingSave so
+// two write_file calls never overlap (which could land out of order).
+let isSaving = false;
+let pendingSave = false;
 let previewWindow = null;
 let isProgrammaticScroll = false;
 let scrollDebounce = null;
@@ -415,49 +419,70 @@ function markDirty() {
     }
 }
 
+// Returns true when the buffer is persisted (or there was nothing to save),
+// false when the write failed. Callers that close the window must honor false.
 async function saveFile() {
-    if (!currentFilePath || !isDirty || !editorView) return;
-
-    let content = editorView.state.doc.toString();
-
-    // For JSON files, normalize to the same pretty-sorted format as preview
-    const lower = currentFilePath.toLowerCase();
-    if (lower.endsWith('.json')) {
-        try {
-            const formatted = await invoke('format_json_pretty', { content });
-            // Rewrite the buffer only when formatting changed it; CM maps the
-            // selection through the change, so the caret stays put.
-            if (formatted !== content) {
-                programmaticChange = true;
-                try {
-                    editorView.dispatch({
-                        changes: { from: 0, to: editorView.state.doc.length, insert: formatted },
-                    });
-                } finally {
-                    programmaticChange = false;
-                }
-                content = formatted;
-            }
-        } catch (e) {
-            console.warn('JSON pretty formatting failed on save; saving raw content:', e);
-        }
+    if (!currentFilePath || !isDirty || !editorView) return true;
+    // A save is already running: let it finish, then flush the newer buffer.
+    if (isSaving) {
+        pendingSave = true;
+        return true;
     }
-
+    isSaving = true;
     try {
-        // Buffer text is LF-normalized; re-apply the file's on-disk EOL mode.
-        const onDisk = inspectorEol === 'CRLF' ? content.replace(/\n/g, '\r\n') : content;
-        await invoke('write_file', { path: currentFilePath, content: onDisk });
-        lastKnownDiskText = content;
-        isDirty = false;
-        updateStatus('Saved');
+        let content = editorView.state.doc.toString();
 
-        // Notify preview window to refresh (fire-and-forget; don't steal focus)
-        if (previewWindow) {
-            invoke('refresh_preview', { window: previewWindow }).catch(() => {});
+        // For JSON files, normalize to the same pretty-sorted format as preview
+        const lower = currentFilePath.toLowerCase();
+        if (lower.endsWith('.json')) {
+            try {
+                const formatted = await invoke('format_json_pretty', { content });
+                // Rewrite the buffer only when formatting changed it; CM maps the
+                // selection through the change, so the caret stays put.
+                if (formatted !== content) {
+                    programmaticChange = true;
+                    try {
+                        editorView.dispatch({
+                            changes: { from: 0, to: editorView.state.doc.length, insert: formatted },
+                        });
+                    } finally {
+                        programmaticChange = false;
+                    }
+                    content = formatted;
+                }
+            } catch (e) {
+                console.warn('JSON pretty formatting failed on save; saving raw content:', e);
+            }
         }
-    } catch (err) {
-        console.error('Failed to save file:', err);
-        updateStatus('Error saving');
+
+        try {
+            // Buffer text is LF-normalized; re-apply the file's on-disk EOL mode.
+            const onDisk = inspectorEol === 'CRLF' ? content.replace(/\n/g, '\r\n') : content;
+            await invoke('write_file', { path: currentFilePath, content: onDisk });
+            lastKnownDiskText = content;
+            // Only clear the dirty flag when the buffer still matches what we
+            // wrote; edits that landed during the write keep it set so the next
+            // save persists them instead of seeing a falsely-clean buffer.
+            isDirty = editorView.state.doc.toString() !== content;
+            updateStatus(isDirty ? 'Modified' : 'Saved');
+
+            // Notify preview window to refresh (fire-and-forget; don't steal focus)
+            if (previewWindow) {
+                invoke('refresh_preview', { window: previewWindow }).catch(() => {});
+            }
+            return true;
+        } catch (err) {
+            console.error('Failed to save file:', err);
+            updateStatus('Error saving');
+            return false;
+        }
+    } finally {
+        isSaving = false;
+        // Edits arrived while this save was in flight: schedule a flush.
+        if (pendingSave) {
+            pendingSave = false;
+            scheduleAutoSave();
+        }
     }
 }
 
@@ -922,7 +947,13 @@ document.addEventListener('DOMContentLoaded', async () => {
             saveTimeout = null;
         }
         if (isDirty) {
-            await saveFile();
+            const ok = await saveFile();
+            if (!ok) {
+                // Save failed (disk full, permission, file replaced): keep the
+                // window and the unsaved buffer rather than discarding edits.
+                // saveFile already set the "Error saving" badge.
+                return;
+            }
         }
         await notifyPreviewEditorClosed();
         appWindow.destroy();


### PR DESCRIPTION
Bumps version to 2.2.1 and fixes five reviewed bugs.

## Fixes
- **High — arbitrary file authorization bypass:** `create_new_window_command` no longer accepts a path. A compromised webview could self-authorize any existing file via `io::allow_path`. It is now blank-window only; file-bearing opens stay in trusted Rust entry points (CLI, Launch Services, recents/menu).
- **High — autosave race / silent data loss:** saves are serialized (`isSaving`/`pendingSave`) and `isDirty` is cleared only when the buffer still matches what was written, so edits made during an in-flight save aren't dropped and overlapping writes can't land out of order.
- **High — close after failed save:** `saveFile` now reports failure and the editor close handler aborts `appWindow.destroy()` on a failed final save instead of discarding the unsaved buffer.
- **Medium — workspace symlink escape:** `walk_workspace` canonicalizes each subdirectory and only recurses when it stays under the workspace root, so the index can't disclose paths outside the granted folder. Regression test added.
- **Medium — stale workspace grant:** closing a workspace now revokes the `allowed_dirs` grant via `io::revoke_dir`, not just the preference.

## Verification
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings` clean
- `cargo test` → 12 passed (incl. new `walk_workspace_skips_symlink_escape`)
- `node --check` on edited JS

🤖 Generated with [Claude Code](https://claude.com/claude-code)